### PR TITLE
refactor: refactor logsService

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ curl "http://localhost:3000/api/v1/logs?fileName=system.log&numEntries=5&keyword
     {
         "serverUrl": "http://localhost:3001",
         "fileName": "system.log",
-        "error": []
+        "errors": []
     },
     {
         "serverUrl": "http://localhost:3000",


### PR DESCRIPTION
Changes:
- switch response error messages array name from "error" to "errors"
- move handling errors to a new function
- switch to Promise.all to wait for all log requests concurrently.